### PR TITLE
Only `require` modules that the current file directly interfaces with

### DIFF
--- a/lib/fake_braintree.rb
+++ b/lib/fake_braintree.rb
@@ -1,21 +1,9 @@
 require 'braintree'
-require 'capybara'
-require 'digest/md5'
 require 'fileutils'
-require 'active_support/core_ext'
-require 'sinatra/base'
-
-require 'fake_braintree/helpers'
-require 'fake_braintree/customer'
-require 'fake_braintree/subscription'
-require 'fake_braintree/redirect'
-require 'fake_braintree/credit_card'
-require 'fake_braintree/address'
+require 'active_support/core_ext/module/attribute_accessors'
 
 require 'fake_braintree/registry'
 require 'fake_braintree/server'
-require 'fake_braintree/sinatra_app'
-require 'fake_braintree/valid_credit_cards'
 require 'fake_braintree/version'
 
 module FakeBraintree

--- a/lib/fake_braintree/address.rb
+++ b/lib/fake_braintree/address.rb
@@ -1,3 +1,5 @@
+require 'fake_braintree/helpers'
+
 module FakeBraintree
   class Address
     include Helpers

--- a/lib/fake_braintree/credit_card.rb
+++ b/lib/fake_braintree/credit_card.rb
@@ -1,3 +1,6 @@
+require 'fake_braintree/helpers'
+require 'fake_braintree/valid_credit_cards'
+
 module FakeBraintree
   class CreditCard
     include Helpers

--- a/lib/fake_braintree/customer.rb
+++ b/lib/fake_braintree/customer.rb
@@ -1,3 +1,7 @@
+require 'fake_braintree/helpers'
+require 'fake_braintree/credit_card'
+require 'fake_braintree/valid_credit_cards'
+
 module FakeBraintree
   class Customer
     include Helpers

--- a/lib/fake_braintree/helpers.rb
+++ b/lib/fake_braintree/helpers.rb
@@ -1,3 +1,6 @@
+require 'digest/md5'
+require 'active_support/gzip'
+
 module FakeBraintree
   module Helpers
     def gzip(content)

--- a/lib/fake_braintree/redirect.rb
+++ b/lib/fake_braintree/redirect.rb
@@ -1,3 +1,9 @@
+require 'uri'
+require 'rack/utils'
+require 'fake_braintree/helpers'
+require 'fake_braintree/credit_card'
+require 'fake_braintree/customer'
+
 module FakeBraintree
   class Redirect
     include Helpers

--- a/lib/fake_braintree/server.rb
+++ b/lib/fake_braintree/server.rb
@@ -1,3 +1,7 @@
+require 'forwardable'
+require 'capybara'
+require 'fake_braintree/sinatra_app'
+
 class FakeBraintree::Server
   def boot
     server = Capybara::Server.new(FakeBraintree::SinatraApp)

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -1,3 +1,11 @@
+require 'sinatra/base'
+require 'active_support/core_ext/hash/conversions'
+require 'fake_braintree/customer'
+require 'fake_braintree/subscription'
+require 'fake_braintree/redirect'
+require 'fake_braintree/credit_card'
+require 'fake_braintree/address'
+
 module FakeBraintree
   class SinatraApp < Sinatra::Base
     set :show_exceptions, false

--- a/lib/fake_braintree/subscription.rb
+++ b/lib/fake_braintree/subscription.rb
@@ -1,3 +1,5 @@
+require 'fake_braintree/helpers'
+
 module FakeBraintree
   class Subscription
     include Helpers


### PR DESCRIPTION
When working on my PR about port numbers, I have noticed that individual files don't require their direct dependencies. Here I propose that #70 gets reverted and the library goes back to declaring dependencies in each individual file based on what that module directly interfaces with.

This has several advantages:

- When looking at a source file, it's immediately obvious what are its dependencies to Ruby stdlib or 3rd-party libraries.

- When changing a specific module in a way that one of the dependencies is no longer necessary, its easier to remember to remove the associated `require`. If all `require`s are in the main library file, in the long term it can be difficult to determine whether each of the require's are still needed.

- Instead of loading whole of `active_support/core_ext`, cherry-pick parts of it that we need in the current file.

I also hoped that instead of loading whole of `capybara`, we could get away with loading just `capybara/server`, because that's the only component of Capybara that we actually need. However, because of Capybara::Server interfaces with global Capybara configuration (namely `Capybara.server`), that's wasn't possible.