### PR TITLE
Fix loading of ActiveSupport::Deprecation for version 4.2

### DIFF
--- a/lib/fake_braintree.rb
+++ b/lib/fake_braintree.rb
@@ -2,6 +2,7 @@ require 'braintree'
 require 'capybara'
 require 'digest/md5'
 require 'fileutils'
+require 'active_support'
 require 'active_support/core_ext'
 require 'sinatra/base'
 


### PR DESCRIPTION
Missing `require active_support`. This file sets up autoloading that the rest of ActiveSupport depends on. Other files might load without it, but it is not guaranteed.