### PR TITLE
New PaymentMethod api

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ of them (yet).
 * `Braintree::Customer.update`
 
 ### PaymentMethod
+* `Braintree::PaymentMethod.create`
 * `Braintree::PaymentMethod.find`
 * `Braintree::PaymentMethod.update`
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ of them (yet).
 
 ### PaymentMethod
 * `Braintree::PaymentMethod.find`
+* `Braintree::PaymentMethod.update`
 
 ### Subscription
 * `Braintree::Subscription.cancel`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ of them (yet).
 * `Braintree::Customer.find`
 * `Braintree::Customer.update`
 
+### PaymentMethod
+* `Braintree::PaymentMethod.find`
+
 ### Subscription
 * `Braintree::Subscription.cancel`
 * `Braintree::Subscription.create`

--- a/lib/fake_braintree.rb
+++ b/lib/fake_braintree.rb
@@ -12,6 +12,7 @@ require 'fake_braintree/subscription'
 require 'fake_braintree/redirect'
 require 'fake_braintree/credit_card'
 require 'fake_braintree/address'
+require 'fake_braintree/payment_method'
 
 require 'fake_braintree/registry'
 require 'fake_braintree/server'

--- a/lib/fake_braintree/payment_method.rb
+++ b/lib/fake_braintree/payment_method.rb
@@ -1,0 +1,9 @@
+module FakeBraintree
+  class PaymentMethod
+    def self.tokenize_card(attributes)
+      token = (Time.now.to_f * 1000).round
+      FakeBraintree.registry.payment_methods[token] = attributes
+      token
+    end
+  end
+end

--- a/lib/fake_braintree/payment_method.rb
+++ b/lib/fake_braintree/payment_method.rb
@@ -1,8 +1,10 @@
+require 'active_support/core_ext/hash/keys'
+
 module FakeBraintree
   class PaymentMethod
     def self.tokenize_card(attributes)
       token = (Time.now.to_f * 1000).round
-      FakeBraintree.registry.payment_methods[token] = attributes
+      FakeBraintree.registry.payment_methods[token] = attributes.stringify_keys
       token
     end
   end

--- a/lib/fake_braintree/registry.rb
+++ b/lib/fake_braintree/registry.rb
@@ -4,16 +4,17 @@ class FakeBraintree::Registry
   end
 
   attr_accessor :customers,:subscriptions, :failures, :transactions, :redirects,
-    :credit_cards, :addresses
+    :credit_cards, :addresses, :payment_methods
 
   def clear!
-    @addresses     = {}
-    @customers     = {}
-    @subscriptions = {}
-    @failures      = {}
-    @transactions  = {}
-    @redirects     = {}
-    @credit_cards  = {}
+    @addresses       = {}
+    @customers       = {}
+    @subscriptions   = {}
+    @failures        = {}
+    @transactions    = {}
+    @redirects       = {}
+    @credit_cards    = {}
+    @payment_methods = {}
   end
 
   def failure?(card_number)

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -125,9 +125,19 @@ module FakeBraintree
       CreditCard.new(updates, options).update
     end
 
+    # Braintree::PaymentMethod.create
     # Braintree::CreditCard.create
     post '/merchants/:merchant_id/payment_methods' do
-      credit_card_hash = hash_from_request_body_with_key('credit_card')
+      request_hash = Hash.from_xml(request.body)
+      request.body.rewind
+
+      credit_card_hash =
+        if request_hash.key?('credit_card')
+          hash_from_request_body_with_key('credit_card')
+        else
+          nonce = request_hash['payment_method']['payment_method_nonce']
+          FakeBraintree.registry.payment_methods[nonce]
+        end
       options = {merchant_id: params[:merchant_id]}
 
       if credit_card_hash['options']

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -135,8 +135,9 @@ module FakeBraintree
         if request_hash.key?('credit_card')
           hash_from_request_body_with_key('credit_card')
         else
-          nonce = request_hash['payment_method']['payment_method_nonce']
-          FakeBraintree.registry.payment_methods[nonce]
+          payment_method_hash = hash_from_request_body_with_key('payment_method')
+          nonce = payment_method_hash.delete('payment_method_nonce')
+          FakeBraintree.registry.payment_methods[nonce].merge(payment_method_hash)
         end
       options = {merchant_id: params[:merchant_id]}
 

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -87,6 +87,16 @@ module FakeBraintree
       Subscription.new(updates, options).update
     end
 
+    # Braintree::PaymentMethod.find
+    get '/merchants/:merchant_id/payment_methods/any/:token' do
+      credit_card = FakeBraintree.registry.credit_cards[params[:token]]
+      if credit_card
+        gzipped_response(200, credit_card.to_xml(root: 'credit_card'))
+      else
+        gzipped_response(404, {})
+      end
+    end
+
     # Braintree::CreditCard.find
     get '/merchants/:merchant_id/payment_methods/credit_card/:credit_card_token' do
       credit_card = FakeBraintree.registry.credit_cards[params[:credit_card_token]]
@@ -108,6 +118,7 @@ module FakeBraintree
 
     # Braintree::CreditCard.create
     post '/merchants/:merchant_id/payment_methods' do
+      puts params
       credit_card_hash = hash_from_request_body_with_key('credit_card')
       options = {merchant_id: params[:merchant_id]}
 

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -97,6 +97,15 @@ module FakeBraintree
       end
     end
 
+    # Braintree::PaymentMethod.update
+    put '/merchants/:merchant_id/payment_methods/any/:token' do
+      credit_card = FakeBraintree.registry.credit_cards[params[:token]]
+      updates     = hash_from_request_body_with_key('payment_method')
+      options     = {token: params[:token], merchant_id: params[:merchant_id]}
+
+      CreditCard.new(updates, options).update
+    end
+
     # Braintree::CreditCard.find
     get '/merchants/:merchant_id/payment_methods/credit_card/:credit_card_token' do
       credit_card = FakeBraintree.registry.credit_cards[params[:credit_card_token]]
@@ -118,7 +127,6 @@ module FakeBraintree
 
     # Braintree::CreditCard.create
     post '/merchants/:merchant_id/payment_methods' do
-      puts params
       credit_card_hash = hash_from_request_body_with_key('credit_card')
       options = {merchant_id: params[:merchant_id]}
 

--- a/spec/fake_braintree/payment_method_spec.rb
+++ b/spec/fake_braintree/payment_method_spec.rb
@@ -107,16 +107,16 @@ describe 'Braintree::PaymentMethod.create' do
   end
 
   describe 'FakeBraintree::PaymentMethod.tokenize_card' do
-  it 'stores provided payment data in the registry' do
-    FakeBraintree::PaymentMethod.tokenize_card number: '4111111111111111'
-    first_payment_method = FakeBraintree.registry.payment_methods.values[0]
-    expect(first_payment_method['number']).to eq '4111111111111111'
-  end
+    it 'stores provided payment data in the registry' do
+      FakeBraintree::PaymentMethod.tokenize_card number: '4111111111111111'
+      first_payment_method = FakeBraintree.registry.payment_methods.values[0]
+      expect(first_payment_method['number']).to eq '4111111111111111'
+    end
 
-  it 'returns key to payment data' do
-    nonce = FakeBraintree::PaymentMethod.tokenize_card number: '4111111111111111'
-    payment_methods = FakeBraintree.registry.payment_methods
-    expect(payment_methods[nonce]['number']).to eq '4111111111111111'
+    it 'returns key to payment data' do
+      nonce = FakeBraintree::PaymentMethod.tokenize_card number: '4111111111111111'
+      payment_methods = FakeBraintree.registry.payment_methods
+      expect(payment_methods[nonce]['number']).to eq '4111111111111111'
+    end
   end
-end
 end

--- a/spec/fake_braintree/payment_method_spec.rb
+++ b/spec/fake_braintree/payment_method_spec.rb
@@ -10,7 +10,7 @@ describe 'Braintree::PaymentMethod.find' do
     expect(credit_card.card_type).to eq "FakeBraintree"
     expect(credit_card.last_4).to eq TEST_CC_NUMBER[-4,4]
     expect(credit_card.expiration_month).to eq month
-    expect(credit_card.expiration_year).to eq  year
+    expect(credit_card.expiration_year).to eq year
     expect(credit_card.unique_number_identifier).to eq TEST_CC_NUMBER
   end
 

--- a/spec/fake_braintree/payment_method_spec.rb
+++ b/spec/fake_braintree/payment_method_spec.rb
@@ -18,3 +18,18 @@ describe 'Braintree::PaymentMethod.find' do
     braintree_credit_card_token(TEST_CC_NUMBER, [month, year].join('/'))
   end
 end
+
+describe 'Braintree::PaymentMethod.update' do
+  it 'successfully updates the credit card' do
+    new_expiration_date = '08/2012'
+    token = cc_token
+
+    result = Braintree::PaymentMethod.update(token, expiration_date: new_expiration_date)
+    expect(result).to be_success
+    expect(Braintree::CreditCard.find(token).expiration_date).to eq new_expiration_date
+  end
+
+  it 'raises an error for a nonexistent credit card' do
+    expect { Braintree::PaymentMethod.update('foo', number: TEST_CC_NUMBER) }.to raise_error(Braintree::NotFoundError)
+  end
+end

--- a/spec/fake_braintree/payment_method_spec.rb
+++ b/spec/fake_braintree/payment_method_spec.rb
@@ -34,16 +34,90 @@ describe 'Braintree::PaymentMethod.update' do
   end
 end
 
-describe 'FakeBraintree::PaymentMethod.tokenize_card' do
+describe 'Braintree::PaymentMethod.create' do
+  it 'allows creating a credit card without a customer' do
+    nonce = FakeBraintree::PaymentMethod.tokenize_card(build_credit_card_hash)
+    result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+
+    expect(result).to be_success
+    expect(Braintree::PaymentMethod.find('token')).to_not be_nil
+  end
+
+  context 'with a customer' do
+    before do
+      @customer = Braintree::Customer.create.customer
+    end
+
+    it 'fails to create a credit card if decline_all_cards is set' do
+      FakeBraintree.decline_all_cards!
+
+      nonce = FakeBraintree::PaymentMethod.tokenize_card(build_credit_card_hash)
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+
+      expect(result).to_not be_success
+      expect { Braintree::PaymentMethod.find('token') }.to raise_error Braintree::NotFoundError
+    end
+
+    it 'fails to create a credit card if verify_all_cards is set and card is invalid' do
+      FakeBraintree.verify_all_cards!
+
+      nonce = FakeBraintree::PaymentMethod.tokenize_card(build_credit_card_hash.merge(number: '12345'))
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+
+      expect(result).to_not be_success
+      expect { Braintree::CreditCard.find('token') }.to raise_error Braintree::NotFoundError
+    end
+
+    it 'successfully creates a credit card' do
+      nonce = FakeBraintree::PaymentMethod.tokenize_card(build_credit_card_hash)
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+
+      expect(result).to be_success
+      expect(Braintree::Customer.find(@customer.id).credit_cards.last.token).to eq 'token'
+      expect(Braintree::Customer.find(@customer.id).credit_cards.last).to be_default
+      expect(Braintree::Customer.find(@customer.id).credit_cards.last.billing_address.postal_code).to eq "94110"
+    end
+
+    it 'only allows one credit card to be default' do
+      nonce = FakeBraintree::PaymentMethod.tokenize_card(build_credit_card_hash)
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+      expect(result).to be_success
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+      expect(result).to be_success
+      # Reload the customer
+      @customer = Braintree::Customer.find(@customer.id)
+      expect(@customer.credit_cards.select(&:default?).length).to eq 1
+      expect(@customer.credit_cards.length).to eq 2
+    end
+  end
+
+  def build_credit_card_hash
+    {
+      customer_id: @customer && @customer.id,
+      number: '4111111111111111',
+      cvv: '123',
+      token: 'token',
+      expiration_date: '07/2020',
+      billing_address: {
+        postal_code: '94110'
+      },
+      options: {
+        make_default: true
+      }
+    }
+  end
+
+  describe 'FakeBraintree::PaymentMethod.tokenize_card' do
   it 'stores provided payment data in the registry' do
     FakeBraintree::PaymentMethod.tokenize_card number: '4111111111111111'
     first_payment_method = FakeBraintree.registry.payment_methods.values[0]
-    expect(first_payment_method[:number]).to eq '4111111111111111'
+    expect(first_payment_method['number']).to eq '4111111111111111'
   end
 
   it 'returns key to payment data' do
     nonce = FakeBraintree::PaymentMethod.tokenize_card number: '4111111111111111'
     payment_methods = FakeBraintree.registry.payment_methods
-    expect(payment_methods[nonce][:number]).to eq '4111111111111111'
+    expect(payment_methods[nonce]['number']).to eq '4111111111111111'
   end
+end
 end

--- a/spec/fake_braintree/payment_method_spec.rb
+++ b/spec/fake_braintree/payment_method_spec.rb
@@ -52,7 +52,7 @@ describe 'Braintree::PaymentMethod.create' do
       FakeBraintree.decline_all_cards!
 
       nonce = FakeBraintree::PaymentMethod.tokenize_card(build_credit_card_hash)
-      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce, customer_id: @customer.id)
 
       expect(result).to_not be_success
       expect { Braintree::PaymentMethod.find('token') }.to raise_error Braintree::NotFoundError
@@ -62,7 +62,7 @@ describe 'Braintree::PaymentMethod.create' do
       FakeBraintree.verify_all_cards!
 
       nonce = FakeBraintree::PaymentMethod.tokenize_card(build_credit_card_hash.merge(number: '12345'))
-      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce, customer_id: @customer.id)
 
       expect(result).to_not be_success
       expect { Braintree::CreditCard.find('token') }.to raise_error Braintree::NotFoundError
@@ -70,7 +70,7 @@ describe 'Braintree::PaymentMethod.create' do
 
     it 'successfully creates a credit card' do
       nonce = FakeBraintree::PaymentMethod.tokenize_card(build_credit_card_hash)
-      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce, customer_id: @customer.id)
 
       expect(result).to be_success
       expect(Braintree::Customer.find(@customer.id).credit_cards.last.token).to eq 'token'
@@ -80,9 +80,9 @@ describe 'Braintree::PaymentMethod.create' do
 
     it 'only allows one credit card to be default' do
       nonce = FakeBraintree::PaymentMethod.tokenize_card(build_credit_card_hash)
-      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce, customer_id: @customer.id)
       expect(result).to be_success
-      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce)
+      result = Braintree::PaymentMethod.create(payment_method_nonce: nonce, customer_id: @customer.id)
       expect(result).to be_success
       # Reload the customer
       @customer = Braintree::Customer.find(@customer.id)
@@ -93,7 +93,6 @@ describe 'Braintree::PaymentMethod.create' do
 
   def build_credit_card_hash
     {
-      customer_id: @customer && @customer.id,
       number: '4111111111111111',
       cvv: '123',
       token: 'token',

--- a/spec/fake_braintree/payment_method_spec.rb
+++ b/spec/fake_braintree/payment_method_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'Braintree::PaymentMethod.find' do
+  it 'gets the correct credit card' do
+    month = '04'
+    year = '2016'
+    credit_card = Braintree::PaymentMethod.find(token_for(month, year))
+
+    expect(credit_card.bin).to eq TEST_CC_NUMBER[0, 6]
+    expect(credit_card.card_type).to eq "FakeBraintree"
+    expect(credit_card.last_4).to eq TEST_CC_NUMBER[-4,4]
+    expect(credit_card.expiration_month).to eq month
+    expect(credit_card.expiration_year).to eq  year
+    expect(credit_card.unique_number_identifier).to eq TEST_CC_NUMBER
+  end
+
+  def token_for(month, year)
+    braintree_credit_card_token(TEST_CC_NUMBER, [month, year].join('/'))
+  end
+end

--- a/spec/fake_braintree/payment_method_spec.rb
+++ b/spec/fake_braintree/payment_method_spec.rb
@@ -33,3 +33,17 @@ describe 'Braintree::PaymentMethod.update' do
     expect { Braintree::PaymentMethod.update('foo', number: TEST_CC_NUMBER) }.to raise_error(Braintree::NotFoundError)
   end
 end
+
+describe 'FakeBraintree::PaymentMethod.tokenize_card' do
+  it 'stores provided payment data in the registry' do
+    FakeBraintree::PaymentMethod.tokenize_card number: '4111111111111111'
+    first_payment_method = FakeBraintree.registry.payment_methods.values[0]
+    expect(first_payment_method[:number]).to eq '4111111111111111'
+  end
+
+  it 'returns key to payment data' do
+    nonce = FakeBraintree::PaymentMethod.tokenize_card number: '4111111111111111'
+    payment_methods = FakeBraintree.registry.payment_methods
+    expect(payment_methods[nonce][:number]).to eq '4111111111111111'
+  end
+end


### PR DESCRIPTION
Supports `Braintree::PaymentMethod.find`, `Braintree::Payment.update`, and `Braintree::Payment.create`.

The **fake_braintree** server will not respond to requests to tokenize credit card data. Instead you need to call `FakeBraintree::PaymentMethod.tokenize_card` manually to generate the nonce.