### PR TITLE
Add Braintree::CreditCard.delete support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ of them (yet).
 
 ### CreditCard
 * `Braintree::CreditCard.create`
+* `Braintree::CreditCard.delete`
 * `Braintree::CreditCard.find`
 * `Braintree::CreditCard.sale`
 * `Braintree::CreditCard.update`

--- a/lib/fake_braintree.rb
+++ b/lib/fake_braintree.rb
@@ -3,9 +3,9 @@ require 'fileutils'
 require 'active_support'
 require 'active_support/core_ext/module/attribute_accessors'
 
+require 'fake_braintree/version'
 require 'fake_braintree/registry'
 require 'fake_braintree/server'
-require 'fake_braintree/version'
 
 module FakeBraintree
   mattr_accessor :registry, :verify_all_cards, :decline_all_cards

--- a/lib/fake_braintree/credit_card.rb
+++ b/lib/fake_braintree/credit_card.rb
@@ -40,6 +40,15 @@ module FakeBraintree
       end
     end
 
+    def delete
+      if credit_card_exists_in_registry?
+        delete_credit_card
+        deletion_response
+      else
+        response_for_card_not_found
+      end
+    end
+
     def to_xml
       @credit_card.to_xml(root: 'credit_card')
     end
@@ -72,6 +81,10 @@ module FakeBraintree
       end
     end
 
+    def delete_credit_card
+      FakeBraintree.registry.credit_cards.delete(token)
+    end
+
     def response_for_updated_card
       gzipped_response(200, @credit_card.to_xml(root: 'credit_card'))
     end
@@ -94,6 +107,10 @@ module FakeBraintree
       ).to_xml(root: 'api_error_response')
 
       gzipped_response(422, body)
+    end
+
+    def deletion_response
+      gzipped_response(200, '')
     end
 
     def expiration_month

--- a/lib/fake_braintree/customer.rb
+++ b/lib/fake_braintree/customer.rb
@@ -43,8 +43,12 @@ module FakeBraintree
     end
 
     def delete
-      delete_customer_with_id(customer_id)
-      deletion_response
+      if customer_exists_in_registry?
+        delete_customer_with_id(customer_id)
+        deletion_response
+      else
+        response_for_customer_not_found
+      end
     end
 
     private
@@ -149,7 +153,7 @@ module FakeBraintree
     end
 
     def delete_customer_with_id(id)
-      FakeBraintree.registry.customers[id] = nil
+      FakeBraintree.registry.customers.delete(id)
     end
 
     def deletion_response

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -134,6 +134,14 @@ module FakeBraintree
       CreditCard.new(updates, options).update
     end
 
+    # Braintree::CreditCard.delete
+    delete '/merchants/:merchant_id/payment_methods/credit_card/:credit_card_token' do
+      cc_hash     = {}
+      options     = {token: params[:credit_card_token], merchant_id: params[:merchant_id]}
+
+      CreditCard.new(cc_hash, options).delete
+    end
+
     # Braintree::PaymentMethod.create
     # Braintree::CreditCard.create
     post '/merchants/:merchant_id/payment_methods' do

--- a/spec/fake_braintree/credit_card_spec.rb
+++ b/spec/fake_braintree/credit_card_spec.rb
@@ -108,3 +108,18 @@ describe 'Braintree::CreditCard.update' do
     expect { Braintree::CreditCard.update('foo', number: TEST_CC_NUMBER) }.to raise_error(Braintree::NotFoundError)
   end
 end
+
+describe 'Braintree::CreditCard.delete' do
+  it 'successfully deletes a credit card' do
+    token = cc_token # creates card
+
+    result = Braintree::CreditCard.delete(token)
+
+    expect(result).to eq true
+    expect { Braintree::CreditCard.find(token) }.to raise_error(Braintree::NotFoundError)
+  end
+
+  it 'raises an error for a nonexistent credit card' do
+    expect { Braintree::CreditCard.delete('foo') }.to raise_error(Braintree::NotFoundError)
+  end
+end


### PR DESCRIPTION
This commit will also changed customer and client delete operations to actually remove the entry entirely from the register (via `delete`, instead setting the key to `nil`).

Also fixed a small issue with active_support includes and rails 4.2.