### PR TITLE
Support updating add_ons and discounts

### DIFF
--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -82,9 +82,8 @@ module FakeBraintree
 
     # Braintree::Subscription.cancel
     put '/merchants/:merchant_id/subscriptions/:id/cancel' do
-      updates = {'status' => Braintree::Subscription::Status::Canceled}
       options = {id: params[:id], merchant_id: params[:merchant_id]}
-      Subscription.new(updates, options).update
+      Subscription.new({}, options).cancel
     end
 
     # Braintree::CreditCard.find

--- a/lib/fake_braintree/subscription.rb
+++ b/lib/fake_braintree/subscription.rb
@@ -63,7 +63,7 @@ module FakeBraintree
 
     def added_add_ons
       if @subscription_hash['add_ons'].is_a?(Hash) && @subscription_hash['add_ons']['add']
-        @subscription_hash['add_ons']['add'].map { |add_on| { 'id' => add_on['inherited_from_id'], 'amount' => add_on['amount'] } }
+        @subscription_hash['add_ons']['add'].map { |add_on| { 'id' => add_on['inherited_from_id'] } }
       else
         []
       end

--- a/lib/fake_braintree/subscription.rb
+++ b/lib/fake_braintree/subscription.rb
@@ -63,7 +63,7 @@ module FakeBraintree
 
     def added_add_ons
       if @subscription_hash['add_ons'].is_a?(Hash) && @subscription_hash['add_ons']['add']
-        @subscription_hash['add_ons']['add'].map { |add_on| { 'id' => add_on['inherited_from_id'] } }
+        @subscription_hash['add_ons']['add'].map { |add_on| { 'id' => add_on['inherited_from_id'], 'amount' => add_on['amount'] } }
       else
         []
       end

--- a/lib/fake_braintree/subscription.rb
+++ b/lib/fake_braintree/subscription.rb
@@ -31,7 +31,7 @@ module FakeBraintree
     def subscription_hash
       @subscription_hash.merge(
         'transactions' => [],
-        'add_ons'   => add_ons,
+        'add_ons' => add_ons,
         'discounts' => discounts,
         'next_billing_date' => braintree_formatted_date(next_billing_date),
         'billing_day_of_month' => billing_day_of_month,

--- a/lib/fake_braintree/subscription.rb
+++ b/lib/fake_braintree/subscription.rb
@@ -26,6 +26,15 @@ module FakeBraintree
       end
     end
 
+    def cancel
+      if subscription_exists_in_registry?
+        canceled_subscription = update_existing_subscription('status' => canceled_status)
+        response_for_canceled_subscription(canceled_subscription)
+      else
+        response_for_subscription_not_found
+      end
+    end
+
     private
 
     def subscription_hash
@@ -133,6 +142,10 @@ module FakeBraintree
       Braintree::Subscription::Status::Active
     end
 
+    def canceled_status
+      Braintree::Subscription::Status::Canceled
+    end
+
     def response_for_created_subscription(hash)
       gzipped_response(201, hash.to_xml(root: 'subscription'))
     end
@@ -141,8 +154,8 @@ module FakeBraintree
       gzipped_response(404, {})
     end
 
-    def response_for_created_subscription(hash)
-      gzipped_response(201, hash.to_xml(root: 'subscription'))
+    def response_for_canceled_subscription(hash)
+      gzipped_response(200, hash.to_xml(root: 'subscription'))
     end
   end
 end

--- a/spec/fake_braintree/subscription_spec.rb
+++ b/spec/fake_braintree/subscription_spec.rb
@@ -96,13 +96,11 @@ describe 'Braintree::Subscription.find' do
 
   it 'returns add-ons added with the subscription' do
     add_on_id = 'def456'
-    amount = BigDecimal.new('20.00')
-    subscription_id = create_subscription(add_ons: { add: [{ inherited_from_id: add_on_id, amount: amount }] }).subscription.id
+    subscription_id = create_subscription(add_ons: { add: [{ inherited_from_id: add_on_id }] }).subscription.id
     subscription = Braintree::Subscription.find(subscription_id)
     add_ons = subscription.add_ons
     expect(add_ons.size).to eq 1
     expect(add_ons.first.id).to eq add_on_id
-    expect(add_ons.first.amount).to eq amount
   end
 
   it 'returns discounts added with the subscription' do

--- a/spec/fake_braintree/subscription_spec.rb
+++ b/spec/fake_braintree/subscription_spec.rb
@@ -177,6 +177,17 @@ describe 'Braintree::Subscription.cancel' do
     expect(Braintree::Subscription.find(subscription_id).status).to eq Braintree::Subscription::Status::Canceled
   end
 
+  it 'leaves discounts and add_ons alone' do
+    discounts = { add: [{ inherited_from_id: 'abc123', quantity: 2 }] }
+    add_ons = { add: [{ inherited_from_id: 'def456', quantity: 4 }] }
+    subscription_id = create_subscription(discounts: discounts, add_ons: add_ons).subscription.id
+
+    expect(Braintree::Subscription.cancel(subscription_id)).to be_success
+    subscription = Braintree::Subscription.find(subscription_id)
+    expect(subscription.discounts).not_to be_empty
+    expect(subscription.add_ons).not_to be_empty
+  end
+
   it 'cannot cancel an unknown subscription' do
     expect { Braintree::Subscription.cancel('totally-bogus-id') }.to raise_error(Braintree::NotFoundError)
   end

--- a/spec/fake_braintree/subscription_spec.rb
+++ b/spec/fake_braintree/subscription_spec.rb
@@ -96,15 +96,27 @@ describe 'Braintree::Subscription.find' do
 
   it 'returns add-ons added with the subscription' do
     add_on_id = 'def456'
-    subscription_id = create_subscription(add_ons: { add: [{ inherited_from_id: add_on_id }] }).subscription.id
+    subscription_id = create_subscription(add_ons: { add: [{ inherited_from_id: add_on_id, amount: 10.50 }] }).subscription.id
     subscription = Braintree::Subscription.find(subscription_id)
     add_ons = subscription.add_ons
     expect(add_ons.size).to eq 1
     expect(add_ons.first.id).to eq add_on_id
+    expect(add_ons.first.amount).to eq 10.50
+  end
+
+  it 'updates existing add-ons' do
+    add_on_id = 'def456'
+    subscription_id = create_subscription(add_ons: { add: [{ inherited_from_id: add_on_id, quantity: 2 }] }).subscription.id
+    update_subscription(subscription_id, add_ons: { update: [{ existing_id: add_on_id, quantity: 5 }] })
+    subscription = Braintree::Subscription.find(subscription_id)
+    add_ons = subscription.add_ons
+    expect(add_ons.size).to eq 1
+    expect(add_ons.first.id).to eq add_on_id
+    expect(add_ons.first.quantity).to eq 5
   end
 
   it 'returns discounts added with the subscription' do
-    discount_id = 'def456'
+    discount_id = 'abc123'
     amount = BigDecimal.new('15.00')
     subscription_id = create_subscription(discounts: { add: [{ inherited_from_id: discount_id, amount: amount }]}).subscription.id
     subscription = Braintree::Subscription.find(subscription_id)
@@ -112,6 +124,17 @@ describe 'Braintree::Subscription.find' do
     expect(discounts.size).to eq 1
     expect(discounts.first.id).to eq discount_id
     expect(discounts.first.amount).to eq amount
+  end
+
+  it 'updates existing discounts' do
+    discount_id = 'abc123'
+    subscription_id = create_subscription(discounts: { add: [{ inherited_from_id: discount_id, quantity: 2 }] }).subscription.id
+    update_subscription(subscription_id, discounts: { update: [{ existing_id: discount_id, quantity: 5 }] })
+    subscription = Braintree::Subscription.find(subscription_id)
+    discounts = subscription.discounts
+    expect(discounts.size).to eq 1
+    expect(discounts.first.id).to eq discount_id
+    expect(discounts.first.quantity).to eq 5
   end
 
   it 'finds subscriptions created with custom id' do

--- a/spec/fake_braintree/subscription_spec.rb
+++ b/spec/fake_braintree/subscription_spec.rb
@@ -96,11 +96,13 @@ describe 'Braintree::Subscription.find' do
 
   it 'returns add-ons added with the subscription' do
     add_on_id = 'def456'
-    subscription_id = create_subscription(add_ons: { add: [{ inherited_from_id: add_on_id }] }).subscription.id
+    amount = BigDecimal.new('20.00')
+    subscription_id = create_subscription(add_ons: { add: [{ inherited_from_id: add_on_id, amount: amount }] }).subscription.id
     subscription = Braintree::Subscription.find(subscription_id)
     add_ons = subscription.add_ons
     expect(add_ons.size).to eq 1
     expect(add_ons.first.id).to eq add_on_id
+    expect(add_ons.first.amount).to eq amount
   end
 
   it 'returns discounts added with the subscription' do

--- a/spec/support/subscription_helpers.rb
+++ b/spec/support/subscription_helpers.rb
@@ -7,4 +7,8 @@ module SubscriptionHelpers
 
     Braintree::Subscription.create(options)
   end
+
+  def update_subscription(subscription_id, user_options = {})
+    Braintree::Subscription.update(subscription_id, user_options)
+  end
 end


### PR DESCRIPTION
This adds support for updating an existing add_on or discount as well as persisting both the `quantity` and `amount` attributes in the registry.